### PR TITLE
Added table of contents endpoint to list all export endpoints and their types

### DIFF
--- a/exportsrv/app.py
+++ b/exportsrv/app.py
@@ -5,7 +5,17 @@ from flask_discoverer import Discoverer
 
 from adsmutils import ADSFlask
 
-from exportsrv.views import bp
+from exportsrv.views import bp, endpoint_registry
+
+def attach_routes_to_registry(app):
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == 'static':
+            continue
+        view_func = app.view_functions[rule.endpoint]
+        for name, entry in endpoint_registry.items():
+            if view_func in entry["handlers"]:
+                if rule.rule not in entry["routes"]:
+                    entry["routes"].append(rule.rule)
 
 def create_app(**config):
     """
@@ -23,6 +33,8 @@ def create_app(**config):
     Discoverer(app)
 
     app.register_blueprint(bp)
+
+    attach_routes_to_registry(app)
     return app
 
 if __name__ == '__main__':


### PR DESCRIPTION
Endpoint: GET `/toc`
Return: `{'BibTeX': {'type': 'tagged'}, ...`
Types are: `['tagged', 'LaTeX', 'XML', 'text', 'custom']`